### PR TITLE
Print with full page mode only when margin is not (0, 0, 0, 0)

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -599,7 +599,8 @@ class Session(object):
         printer.setOutputFormat(QPrinter.PdfFormat)
         printer.setPaperSize(QtCore.QSizeF(*paper_size), paper_units)
         printer.setPageMargins(*(paper_margins + (paper_units,)))
-        printer.setFullPage(True)
+        if paper_margins != (0, 0, 0, 0):
+            printer.setFullPage(True)
         printer.setOutputFileName(path)
         if self.webview is None:
             self.webview = QtWebKit.QWebView()


### PR DESCRIPTION
Print with full page mode only when margin is not (0, 0, 0, 0), since when full page mode is enabled, the margin will be ignored. Base on http://doc.qt.io/qt-5/qprinter.html#setPageMargins .
